### PR TITLE
Log warning when statusCode != 200 is returned

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": "*"
   },
   "scripts": {
-    "test": "cd test && grunt"
+    "test": "cd test && grunt --force"
   },
   "dependencies": {
     "request": "~2.12.0",

--- a/tasks/curl.js
+++ b/tasks/curl.js
@@ -43,7 +43,7 @@ module.exports = function (grunt) {
     function curlResultFn(err, files) {
       // If there is an error, fail
       if (err) {
-        return grunt.fail.fatal(err);
+        grunt.fail.warn(err);
       }
 
       // Concatenate the srcFiles, process the blob through our helper,
@@ -54,9 +54,6 @@ module.exports = function (grunt) {
       var destDir = path.dirname(dest);
       grunt.file.mkdir(destDir);
       fs.writeFileSync(dest, content, 'binary');
-
-      // Fail task if errors were logged.
-      if (that.errorCount) { return false; }
 
       // Otherwise, print a success message.
       grunt.log.writeln('File "' + dest + '" created.');
@@ -99,7 +96,7 @@ module.exports = function (grunt) {
     function curlResultFn(err, files) {
       // If there is an error, fail
       if (err) {
-        return grunt.fail.fatal(err);
+        grunt.fail.warn(err);
       }
 
       // Determine the destinations
@@ -119,9 +116,6 @@ module.exports = function (grunt) {
         fs.writeFileSync(destPath, content, 'binary');
       });
 
-      // Fail task if errors were logged.
-      if (that.errorCount) { return false; }
-
       // Otherwise, print a success message.
       grunt.log.writeln('Files "' + destArr.join('", "') + '" created.');
 
@@ -139,6 +133,9 @@ module.exports = function (grunt) {
     // Request the url
     request.get({'url': url, 'encoding': 'binary'}, function (err, res, body) {
       // Callback with the error and body
+      if (res && res.statusCode !== 200) {
+        err = new Error('Fetching "' + url + '" failed with HTTP status code ' + res.statusCode);
+      }
       cb(err, body);
     });
   });

--- a/test/Gruntfile.js
+++ b/test/Gruntfile.js
@@ -10,6 +10,14 @@ module.exports = function (grunt) {
       zip: {
         src: 'https://github.com/twitter/bootstrap/blob/91b92f9dd09c1794d02c6157daba5405d8f09e39/assets/bootstrap.zip?raw=true',
         dest: 'actual/file.zip'
+      },
+      nonExistingDomain: {
+        src: 'http://nonexistent--foo--domain',
+        dest: 'actual/nonexistent-domain'
+      },
+      nonExistingFile: {
+        src: 'https://github.com/nonexistent--foo--file',
+        dest: 'actual/nonexistent-file'
       }
     },
     'curl-dir': {

--- a/test/curl_test.js
+++ b/test/curl_test.js
@@ -41,5 +41,19 @@ exports['curl'] = {
         actualContent = fs.readFileSync('actual/file.zip', 'binary');
     test.equal(actualContent, expectedContent, 'should return the correct value.');
     test.done();
+  },
+  'nonExistingDomain': function(test) {
+    test.expect(1);
+    test.throws(function() {
+      fs.readFileSync('nonexistent-domain', 'binary');
+    });
+    test.done();
+  },
+  'nonExistingFile': function(test) {
+    test.expect(1);
+    test.throws(function() {
+      fs.readFileSync('nonexistent-file', 'binary');
+    });
+    test.done();
   }
 };

--- a/test/grunt.js
+++ b/test/grunt.js
@@ -10,6 +10,14 @@ module.exports = function (grunt) {
       zip: {
         src: 'https://github.com/twitter/bootstrap/blob/91b92f9dd09c1794d02c6157daba5405d8f09e39/assets/bootstrap.zip?raw=true',
         dest: 'actual/file.zip'
+      },
+      nonExistingDomain: {
+        src: 'http://nonexistent--foo--domain',
+        dest: 'actual/nonexistent-domain'
+      },
+      nonExistingFile: {
+        src: 'https://github.com/nonexistent--foo--file',
+        dest: 'actual/nonexistent-file'
       }
     },
     'curl-dir': {


### PR DESCRIPTION
It also adds a test when a non-existent domain was requested.

Had to put `npm test` to use `grunt --force` to test warnings that could be logged by grunt-curl. I've executed the tests with grunt 0.4.1 and 0.3.17.

From the grunt docs:

grunt.fail.warn('Something went wrong.'); logs a warning in bright yellow, exiting grunt with exit code 1, unless --force was specified.
