### PR TITLE
Write result only if `dest` option is present

### DIFF
--- a/tasks/curl.js
+++ b/tasks/curl.js
@@ -50,13 +50,15 @@ module.exports = function (grunt) {
       var separator = data.separator || '\n',
           content = files.join(separator);
 
-      // Write out the content
-      var destDir = path.dirname(dest);
-      grunt.file.mkdir(destDir);
-      fs.writeFileSync(dest, content, 'binary');
+      // Write out the content if `dest` option present.
+      if (dest) {
+        var destDir = path.dirname(dest);
+        grunt.file.mkdir(destDir);
+        fs.writeFileSync(dest, content, 'binary');
 
-      // Otherwise, print a success message.
-      grunt.log.writeln('File "' + dest + '" created.');
+        // Otherwise, print a success message.
+        grunt.log.writeln('File "' + dest + '" created.');
+      }
 
       // Callback
       done();

--- a/test/curl_test_content.js
+++ b/test/curl_test_content.js
@@ -74,6 +74,10 @@ module.exports = {
     this.task = 'nonExistingFile';
     this.filenames = ['nonexistent-file'];
   }, 'execute task'],
+  'without dest option': [function () {
+    this.task = 'noDest';
+    this.filenames = [];
+  },  'execute task'],
 
   // curl-dir tasks
   'downloading multiple files': [function () {

--- a/test/curl_test_outline.yml
+++ b/test/curl_test_outline.yml
@@ -15,6 +15,8 @@
       - 'does not create the file'
   - 'downloading a POST file':
     - 'is successful'
+  - 'without dest option':
+    - 'is successful'
 # curl-dir tests
 - 'grunt curl-dir':
   - 'downloading multiple files':

--- a/test/grunt.js
+++ b/test/grunt.js
@@ -31,6 +31,9 @@ module.exports = function (grunt) {
       nonExistingFile: {
         src: 'https://github.com/nonexistent--foo--file',
         dest: 'actual/nonexistent-file'
+      },
+      noDest: {
+        src: 'http://cdnjs.cloudflare.com/ajax/libs/labjs/2.0.3/LAB.min.js'
       }
     },
     'curl-dir': {


### PR DESCRIPTION
This PR makes `dest` setting optional. Useful when all I need is to ping an URL.
