### PR TITLE
Remove grunt.util.async and grunt.util._

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "test": "doubleshot"
   },
   "dependencies": {
-    "request": "~2.21.0",
-    "grunt-retro": "~0.7.0"
+    "request": "~2.33.0",
+    "grunt-retro": "~0.7.0",
+    "async": "~0.2.10",
+    "lodash": "~2.4.1"
   },
   "_devDependencies": {
     "grunt": "~0.3.17",
@@ -43,8 +45,8 @@
   "devDependencies": {
     "grunt": "~0.4.0",
     "doubleshot": "~2.13.1",
-    "chai": "~1.5.0",
-    "grunt-contrib-clean": "~0.4.1",
+    "chai": "~1.9.0",
+    "grunt-contrib-clean": "~0.5.0",
     "express": "~3.4.4"
   },
   "keywords": [

--- a/tasks/curl.js
+++ b/tasks/curl.js
@@ -9,7 +9,9 @@
 var fs = require('fs'),
     path = require('path'),
     gruntRetro = require('grunt-retro'),
-    request = require('request');
+    request = require('request'),
+    async = require('async'),
+    _ = require('lodash');
 module.exports = function (grunt) {
   // Load in grunt-retro
   grunt = gruntRetro(grunt);
@@ -37,7 +39,6 @@ module.exports = function (grunt) {
     }
 
     // Asynchronously fetch the files in parallel
-    var async = grunt.utils.async;
     async.map(srcFiles, grunt.helper.bind(grunt, 'curl'), curlResultFn);
 
     function curlResultFn(err, files) {
@@ -94,7 +95,6 @@ module.exports = function (grunt) {
     }, []);
 
     // Asynchronously fetch the files in parallel
-    var async = grunt.utils.async;
     async.map(srcFiles, grunt.helper.bind(grunt, 'curl'), curlResultFn);
 
     function curlResultFn(err, files) {
@@ -133,7 +133,6 @@ module.exports = function (grunt) {
   // ==========================================================================
 
   // Register our curl helper
-  var _ = grunt.util._;
   grunt.registerHelper('curl', function (options, cb) {
     // Default to a binary request
     if (typeof options === 'string') {


### PR DESCRIPTION
[`grunt.util.async`](http://gruntjs.com/api/grunt.util#grunt.util.async) and [`grunt.util._`](http://gruntjs.com/api/grunt.util#grunt.util._) are [deprecated](http://gruntjs.com/blog/2013-11-21-grunt-0.4.2-released).
So I replaced them with [async](https://github.com/caolan/async) module and [extend](https://github.com/justmoon/node-extend) module.
