### PR TITLE
Added ifMissing functionality to curl-dir

### DIFF
--- a/test/curl-dir_test.js
+++ b/test/curl-dir_test.js
@@ -30,6 +30,31 @@ describe('grunt curl-dir', function () {
     });
   });
 
+  describe('downloading multiple files multiple times', function () {
+    gruntUtils.runTask('curl-dir:multi_ifMissing');
+    gruntUtils.runTask('curl-dir:multi_ifMissing');
+
+    describe('the first file', function () {
+      fsUtils.readExpectedFile('multi/LAB.min.js', 'utf8');
+      fsUtils.readActualFile('multi/LAB.min.js', 'utf8');
+
+      it('is successfully downloaded', function () {
+        expect(this.err).to.equal(null);
+        expect(this.actualContent).to.equal(this.expectedContent);
+      });
+    });
+
+    describe('the second file', function () {
+      fsUtils.readExpectedFile('multi/cookiejar.js', 'utf8');
+      fsUtils.readActualFile('multi/cookiejar.js', 'utf8');
+
+      it('is successfully downloaded', function () {
+        expect(this.err).to.equal(null);
+        expect(this.actualContent).to.equal(this.expectedContent);
+      });
+    });
+  });
+
   describe('downloading brace expanded files', function () {
     gruntUtils.runTask('curl-dir:braceExpansion');
 

--- a/test/grunt.js
+++ b/test/grunt.js
@@ -48,6 +48,14 @@ module.exports = function (grunt) {
         ],
         dest: 'actual/multi'
       },
+      multi_ifMissing: {
+        ifMissing: true,
+        src: [
+          'http://cdnjs.cloudflare.com/ajax/libs/labjs/2.0.3/LAB.min.js',
+          'http://cdnjs.cloudflare.com/ajax/libs/cookiejar/0.5/cookiejar.js'
+        ],
+        dest: 'actual/multi_ifMissing'
+      },
       braceExpansion: {
         src: [
           'http://cdnjs.cloudflare.com/ajax/libs/{labjs/2.0.3/LAB.min,cookiejar/0.5/cookiejar}.js'


### PR DESCRIPTION
This is an attempt to implement an "if missing" like functionality: files are downloaded only if they are missing.
This is a bit far from #17 but goes into the direction of saving time and bandwidth
